### PR TITLE
Dev v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-### Added
+### New
 
 - New `disableColor` option so you can disable all color/style options besides the white space formatting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.0
+
+### Added
+
+- New `disableColor` option so you can disable all color/style options besides the white space formatting
+
 ## v0.2.0
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - New `disableColor` option so you can disable all color/style options besides the white space formatting
 
+### Improved
+
+- Respect bailouts when they come back in the results
+
+### Fixed
+
+- If tape errors out, the error should now bubble back to the terminal instead of getting consumed by tap-on
+
 ## v0.2.0
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you need or want to use tap-on and it comes out ugle, or just flat out doesn'
 
 - `-s, --stack`: This param will **hide** the stack trace in the fail messages you will still see the **at** however
 - `-u, --summarize`: Enables failure summaries at the **END** of your test report, useful if you have a lot of tests!
+- `-d, --disableColor`: Disables the styled output, and only keeps the icons, and spacing
 
 ## Installation
 

--- a/bin/tap-on
+++ b/bin/tap-on
@@ -5,7 +5,8 @@ const parsedArgs = require('minimist')(process.argv.slice(2), {
   alias: {
     v: 'version',
     s: 'stack',
-    u: 'summarize'
+    u: 'summarize',
+    d: 'disableColor'
   }
 })
 const { version } = require('../package.json')

--- a/bin/tap-on
+++ b/bin/tap-on
@@ -19,4 +19,14 @@ if (parsedArgs.version) {
   process.stdin
     .pipe(tapOn(parsedArgs))
     .pipe(process.stdout)
+
+  process.on('exit', function (status) {
+    if (status === 1) {
+      process.exit(1)
+    }
+
+    if (tapOn.failed) {
+      process.exit(1)
+    }
+  })
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { bold, dim, underline, green, cyan, red } = require('colorette')
+const { bold, cyan, dim, green, options, red, underline } = require('colorette')
 const through = require('through2')
 const duplexer = require('duplexer3')
 const Parser = require('tap-parser')
@@ -42,6 +42,10 @@ function tapOn (args) {
   const stream = duplexer(tap, output)
   let skippedTests = 0
   let lastStr = ''
+
+  if (args.disableColor) {
+    options.enabled = false
+  }
 
   tap.on('pass', assert => {
     output.push(pad(`${green(symbols.tick)} ${dim(assert.name)}\n`, 4))

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function tapOn (args) {
 
   tap.on('fail', assert => {
     output.push(formatFail(assert, args.stack))
+
+    stream.failed = true
   })
 
   tap.on('skip', assert => {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ function tapOn (args) {
   })
 
   tap.on('complete', results => {
+    if ((results.count === 0 && results.skip === 0) || results.bailout) {
+      process.exit(1)
+    }
+
     if (args.summarize) {
       const failCount = results.failures.length
       const [past, plural] = failCount === 1 ? ['was', 'failure'] : ['were', 'failures']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-on",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -316,19 +316,6 @@
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
       }
     },
     "debug": {
@@ -1487,18 +1474,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      }
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -1532,12 +1507,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1582,12 +1551,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1598,51 +1561,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "npm-run-all": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "pidtree": "^0.3.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "object-assign": {
@@ -1799,37 +1717,10 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
-    "pidtree": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
-      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
-      "dev": true
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pkg-conf": {
@@ -1955,17 +1846,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
     },
     "read-pkg-up": {
       "version": "2.0.0",
@@ -2095,27 +1975,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
     "side-channel": {
@@ -2322,17 +2181,6 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
-      }
-    },
-    "string.prototype.padend": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
-      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
       }
     },
     "string.prototype.trim": {
@@ -2595,15 +2443,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
       }
     },
     "which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "tap-on",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A nicer way to handle tap output",
   "main": "index.js",
   "scripts": {
     "prepack": "npm run lint",
     "test": "tape tests/pass.js | cross-env bin/tap-on",
+    "test:no:color": "tape tests/pass.js | cross-env bin/tap-on -d",
     "lint": "standard index.js | snazzy"
   },
   "bin": {
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "npm-run-all": "4.1.5",
     "snazzy": "9.0.0",
     "standard": "16.0.3",
     "tape": "5.3.1"


### PR DESCRIPTION
## New

- New `disableColor` option so you can disable all color/style options besides the white space formatting

## Improved

- Respect bailouts when they come back in the results

## Fixed

- If tape errors out, the error should now bubble back to the terminal instead of getting consumed by tap-on